### PR TITLE
Home ページ実装 #4

### DIFF
--- a/src/components/ExternalLinks.astro
+++ b/src/components/ExternalLinks.astro
@@ -1,0 +1,51 @@
+---
+interface Link {
+  label: string;
+  href: string;
+  external?: boolean;
+}
+
+interface Props {
+  links: Link[];
+}
+
+const { links } = Astro.props;
+---
+
+<section class="external-links">
+  <h2>Links</h2>
+  <ul>
+    {
+      links.map((link) => (
+        <li>
+          <a
+            href={link.href}
+            target={link.external ? '_blank' : undefined}
+            rel={link.external ? 'noopener noreferrer' : undefined}
+          >
+            {link.label}
+          </a>
+        </li>
+      ))
+    }
+  </ul>
+</section>
+
+<style>
+  .external-links {
+    margin-bottom: var(--space-12);
+  }
+
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-6);
+  }
+
+  a {
+    font-size: 0.9375rem;
+  }
+</style>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,0 +1,27 @@
+---
+interface Props {
+  name: string;
+  tagline: string;
+}
+
+const { name, tagline } = Astro.props;
+---
+
+<header class="hero">
+  <h1>{name}</h1>
+  <p class="tagline">{tagline}</p>
+</header>
+
+<style>
+  .hero {
+    margin-bottom: var(--space-16);
+  }
+
+  .tagline {
+    font-size: 1.0625rem;
+    line-height: 1.6;
+    color: var(--fg);
+    margin: 0;
+    max-width: 36rem;
+  }
+</style>

--- a/src/components/Skills.astro
+++ b/src/components/Skills.astro
@@ -1,0 +1,70 @@
+---
+interface SkillCategory {
+  name: string;
+  items: string[];
+}
+
+interface Props {
+  categories: SkillCategory[];
+}
+
+const { categories } = Astro.props;
+---
+
+<section class="skills">
+  <h2>Skills</h2>
+  <dl>
+    {
+      categories.map((category) => (
+        <div class="row">
+          <dt>{category.name}</dt>
+          <dd>{category.items.join(' / ')}</dd>
+        </div>
+      ))
+    }
+  </dl>
+</section>
+
+<style>
+  .skills {
+    margin-bottom: var(--space-16);
+  }
+
+  dl {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+  }
+
+  .row {
+    display: grid;
+    grid-template-columns: 11rem 1fr;
+    gap: var(--space-4);
+    padding: var(--space-3) 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .row:last-child {
+    border-bottom: none;
+  }
+
+  dt {
+    font-size: 0.875rem;
+    color: var(--fg-subtle);
+    font-weight: 500;
+  }
+
+  dd {
+    margin: 0;
+    color: var(--fg);
+    font-size: 0.9375rem;
+  }
+
+  @media (max-width: 560px) {
+    .row {
+      grid-template-columns: 1fr;
+      gap: var(--space-1);
+    }
+  }
+</style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,0 +1,176 @@
+---
+interface Props {
+  title?: string;
+  description?: string;
+}
+
+const {
+  title = 'cilly-yllic',
+  description = 'Full-cycle web engineer focused on scalable architecture, AI-integrated systems, and product-oriented development.',
+} = Astro.props;
+
+const ogImage = new URL('/og-image.png', Astro.site).toString();
+const canonical = new URL(Astro.url.pathname, Astro.site).toString();
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="generator" content={Astro.generator} />
+
+    <title>{title}</title>
+    <meta name="description" content={description} />
+    <link rel="canonical" href={canonical} />
+
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:url" content={canonical} />
+    <meta property="og:image" content={ogImage} />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={ogImage} />
+  </head>
+  <body>
+    <main>
+      <slot />
+    </main>
+  </body>
+</html>
+
+<style is:global>
+  :root {
+    --bg: #ffffff;
+    --fg: #1a1a1a;
+    --fg-muted: #555555;
+    --fg-subtle: #888888;
+    --border: #e5e5e5;
+    --accent: #1a1a1a;
+    --link: #1a1a1a;
+    --link-hover: #000000;
+
+    --font-sans:
+      ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue',
+      Arial, 'Hiragino Sans', 'Hiragino Kaku Gothic ProN', Meiryo, sans-serif;
+    --font-mono:
+      ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono',
+      monospace;
+
+    --max-w: 720px;
+    --space-1: 0.25rem;
+    --space-2: 0.5rem;
+    --space-3: 0.75rem;
+    --space-4: 1rem;
+    --space-6: 1.5rem;
+    --space-8: 2rem;
+    --space-12: 3rem;
+    --space-16: 4rem;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0e0e10;
+      --fg: #ededed;
+      --fg-muted: #b5b5b5;
+      --fg-subtle: #7a7a7a;
+      --border: #27272a;
+      --accent: #ededed;
+      --link: #ededed;
+      --link-hover: #ffffff;
+    }
+  }
+
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  html {
+    -webkit-text-size-adjust: 100%;
+    text-rendering: optimizeLegibility;
+  }
+
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--fg);
+    font-family: var(--font-sans);
+    font-size: 16px;
+    line-height: 1.7;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  main {
+    max-width: var(--max-w);
+    margin: 0 auto;
+    padding: var(--space-16) var(--space-6);
+  }
+
+  h1,
+  h2,
+  h3 {
+    color: var(--fg);
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    line-height: 1.3;
+  }
+
+  h1 {
+    font-size: 1.75rem;
+    margin: 0 0 var(--space-4);
+  }
+
+  h2 {
+    font-size: 1.05rem;
+    margin: 0 0 var(--space-4);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fg-subtle);
+    font-weight: 500;
+  }
+
+  p {
+    margin: 0 0 var(--space-4);
+    color: var(--fg-muted);
+  }
+
+  a {
+    color: var(--link);
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 3px;
+    transition: color 0.15s ease;
+  }
+
+  a:hover {
+    color: var(--link-hover);
+  }
+
+  a:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.92em;
+  }
+
+  ::selection {
+    background: var(--fg);
+    color: var(--bg);
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,38 +1,53 @@
 ---
-const title = 'cilly-yllic';
-const description = 'Full-cycle web engineer focused on scalable architecture, AI-integrated systems, and product-oriented development.';
-const ogImage = new URL('/og-image.png', Astro.site).toString();
-const canonical = new URL(Astro.url.pathname, Astro.site).toString();
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Hero from '../components/Hero.astro';
+import Skills from '../components/Skills.astro';
+import ExternalLinks from '../components/ExternalLinks.astro';
+
+const skillCategories = [
+  {
+    name: 'Frontend',
+    items: ['TypeScript', 'Next.js', 'Nuxt.js', 'Vue.js'],
+  },
+  {
+    name: 'Backend',
+    items: ['TypeScript', 'NestJS', 'Node.js'],
+  },
+  {
+    name: 'Infrastructure',
+    items: ['Google Cloud', 'Firebase', 'GitHub Actions'],
+  },
+  {
+    name: 'Architecture',
+    items: ['Nx', 'Turborepo', 'Event-driven', 'Multi-tenant'],
+  },
+  {
+    name: 'AI Integration',
+    items: ['LLM-assisted Workflows', 'AI Coding Pipelines'],
+  },
+  {
+    name: 'Realtime Systems',
+    items: ['Firestore', 'Cloud Tasks', 'Reconciliation'],
+  },
+  {
+    name: 'Search / Data',
+    items: ['OpenSearch', 'MySQL', 'Firestore'],
+  },
+];
+
+const links = [
+  { label: 'GitHub', href: 'https://github.com/cilly-yllic', external: true },
+  { label: 'X', href: '#', external: true },
+  { label: 'Resume', href: '#', external: true },
+  { label: 'Contact', href: 'mailto:yoshihiro.okuda@mooodone.com' },
+];
 ---
 
-<html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<meta name="generator" content={Astro.generator} />
-
-		<title>{title}</title>
-		<meta name="description" content={description} />
-		<link rel="canonical" href={canonical} />
-
-		<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-		<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-		<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-
-		<meta property="og:type" content="website" />
-		<meta property="og:title" content={title} />
-		<meta property="og:description" content={description} />
-		<meta property="og:url" content={canonical} />
-		<meta property="og:image" content={ogImage} />
-		<meta property="og:image:width" content="1200" />
-		<meta property="og:image:height" content="630" />
-
-		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content={title} />
-		<meta name="twitter:description" content={description} />
-		<meta name="twitter:image" content={ogImage} />
-	</head>
-	<body>
-		<h1>{title}</h1>
-	</body>
-</html>
+<BaseLayout>
+  <Hero
+    name="cilly-yllic"
+    tagline="Full-cycle web engineer focused on scalable architecture, AI-integrated systems, and product-oriented development."
+  />
+  <Skills categories={skillCategories} />
+  <ExternalLinks links={links} />
+</BaseLayout>


### PR DESCRIPTION
## Summary

- `BaseLayout.astro` を新設し、meta タグ・グローバル CSS・ダークモードトークンを集約
- `Hero` / `Skills` / `ExternalLinks` をコンポーネント化
- 仕様書の Skills カテゴリ (Frontend / Backend / Infrastructure / Architecture / AI Integration / Realtime Systems / Search・Data) と技術一覧を反映
- スキルバー・Generic Portfolio Template を避け、純テキスト列挙の `<dl>` レイアウト
- ダークモードは `prefers-color-scheme` で自動追従 (トグル UI は #8 のスコープ)
- 中央寄せ max-width 720px、focus-visible リング、レスポンシブ (560px 以下で Skills を 1 カラム)

## 完了条件

- [x] Hero Section
- [x] Skills (カテゴリ + 技術一覧、スキルバーなし)
- [x] External Links
- [x] ダークモードで崩れない

## Test plan

- [ ] `npm run dev` でローカル表示確認
- [ ] OS の light / dark で見た目が崩れない
- [ ] モバイル幅 (< 560px) で Skills が縦並びになる
- [ ] フォーカスでリンクに outline が出る (キーボード Tab)

## 未確定の項目 (別途指示を待ちます)

- X のハンドル (現状 `#` プレースホルダ)
- Resume の URL (現状 `#` プレースホルダ)

## 関連

Epic Issue #2
Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)