### PR TITLE
Playground / OSS / About / Contact ページ実装 #7

### DIFF
--- a/src/components/StatusCard.astro
+++ b/src/components/StatusCard.astro
@@ -1,0 +1,80 @@
+---
+type Status = 'Available' | 'Coming Soon' | 'Planned' | 'Archived';
+
+interface Props {
+  title: string;
+  description: string;
+  status: Status;
+  href?: string;
+}
+
+const { title, description, status, href } = Astro.props;
+const isInteractive = !!href && status === 'Available';
+---
+
+<article class:list={['card', { interactive: isInteractive }]}>
+  {
+    isInteractive ? (
+      <a href={href} class="title-link">
+        <h3>{title}</h3>
+      </a>
+    ) : (
+      <h3>{title}</h3>
+    )
+  }
+  <p class="description">{description}</p>
+  <p class:list={['status', `status-${status.replace(/\s+/g, '-').toLowerCase()}`]}>
+    {status}
+  </p>
+</article>
+
+<style>
+  .card {
+    padding: var(--space-6) 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .card:last-child {
+    border-bottom: none;
+  }
+
+  .title-link {
+    text-decoration: none;
+    color: var(--fg);
+  }
+
+  .title-link:hover h3 {
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 4px;
+  }
+
+  h3 {
+    margin: 0 0 var(--space-2);
+    font-size: 1.0625rem;
+    font-weight: 600;
+    color: var(--fg);
+    text-transform: none;
+    letter-spacing: -0.01em;
+  }
+
+  .description {
+    margin: 0 0 var(--space-3);
+    color: var(--fg-muted);
+    font-size: 0.9375rem;
+    line-height: 1.6;
+  }
+
+  .status {
+    margin: 0;
+    display: inline-block;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fg-subtle);
+  }
+
+  .status-available {
+    color: var(--fg);
+  }
+</style>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,0 +1,144 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Section from '../components/Section.astro';
+
+const interests = [
+  'Distributed Systems',
+  'Event-driven Architecture',
+  'AI-assisted Development',
+  'Product Architecture',
+  'Realtime Systems',
+];
+
+const values = [
+  {
+    name: 'Maintainability',
+    detail: '6 ヶ月後に他人が読んで意味の取れるコードと、6 ヶ月後に自分が読んで意味の取れる設計。',
+  },
+  {
+    name: 'Scalability',
+    detail: '今 10 倍にしたら何が壊れるかを、設計の段階で言えること。',
+  },
+  {
+    name: 'Readability',
+    detail: '優先順位として速度 < 正確さ < 読みやすさ。最後が最も長く効く。',
+  },
+  {
+    name: 'Explicit Architecture',
+    detail: 'システムの境界・責務・データの流れを言葉と図にできること。暗黙の前提を最小化する。',
+  },
+  {
+    name: 'Operational Simplicity',
+    detail: '運用フェーズで複雑なものは設計フェーズに戻す。複雑さは「移動」できるが「消滅」させづらい。',
+  },
+];
+---
+
+<BaseLayout
+  title="About · cilly-yllic"
+  description="エンジニアとしての関心領域、設計上重視していること。"
+>
+  <nav class="back">
+    <a href="/">← Home</a>
+  </nav>
+
+  <header class="page-header">
+    <p class="eyebrow">About</p>
+    <h1>About me</h1>
+    <p class="lead">
+      フロント / バック / インフラ / アーキテクチャを跨いで動く Web エンジニア。
+      個人プロダクトと業務委託の両方で、システムの境界設計と AI 統合を中心に
+      手を動かしている。
+    </p>
+  </header>
+
+  <Section title="興味領域">
+    <ul class="bullet-list">
+      {interests.map((item) => <li>{item}</li>)}
+    </ul>
+  </Section>
+
+  <Section title="重視していること">
+    <dl class="values">
+      {
+        values.map((v) => (
+          <div class="value-row">
+            <dt>{v.name}</dt>
+            <dd>{v.detail}</dd>
+          </div>
+        ))
+      }
+    </dl>
+  </Section>
+</BaseLayout>
+
+<style>
+  .back {
+    margin-bottom: var(--space-8);
+    font-size: 0.875rem;
+  }
+
+  .page-header {
+    margin-bottom: var(--space-16);
+  }
+
+  .eyebrow {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--fg-subtle);
+    margin: 0 0 var(--space-2);
+  }
+
+  .page-header h1 {
+    font-size: 2rem;
+    margin: 0 0 var(--space-4);
+  }
+
+  .lead {
+    font-size: 1.0625rem;
+    color: var(--fg);
+    max-width: 36rem;
+    margin: 0;
+  }
+
+  .bullet-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-4) var(--space-6);
+  }
+
+  .bullet-list li {
+    font-size: 0.9375rem;
+    color: var(--fg);
+  }
+
+  .values {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-6);
+  }
+
+  .value-row {
+    border-left: 2px solid var(--border);
+    padding-left: var(--space-4);
+  }
+
+  dt {
+    color: var(--fg);
+    font-weight: 600;
+    font-size: 0.9375rem;
+    margin-bottom: var(--space-2);
+  }
+
+  dd {
+    margin: 0;
+    color: var(--fg-muted);
+    font-size: 0.9375rem;
+    line-height: 1.7;
+  }
+</style>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,0 +1,149 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+interface ContactItem {
+  channel: string;
+  href: string;
+  detail: string;
+  external?: boolean;
+}
+
+const items: ContactItem[] = [
+  {
+    channel: 'GitHub',
+    href: 'https://github.com/cilly-yllic',
+    detail: 'コード・ライブラリ・本サイトのソース。',
+    external: true,
+  },
+  {
+    channel: 'X',
+    href: '#',
+    detail: '技術的な短い発信。ハンドルは追って追記。',
+    external: true,
+  },
+  {
+    channel: 'Business Inquiry',
+    href: 'https://mooodone.com/',
+    detail:
+      '業務委託・技術アドバイザリ・アーキテクチャレビューの相談はこちら経由でお願いします。スコープ / 期間 / 期待する成果物を添えていただけると話が早いです。',
+    external: true,
+  },
+];
+---
+
+<BaseLayout
+  title="Contact · cilly-yllic"
+  description="連絡先・業務委託の問い合わせ。"
+>
+  <nav class="back">
+    <a href="/">← Home</a>
+  </nav>
+
+  <header class="page-header">
+    <p class="eyebrow">Contact</p>
+    <h1>Get in touch</h1>
+    <p class="lead">
+      技術的な発信や本サイトのソースは GitHub / X から。
+      業務委託の問い合わせは Business Inquiry のリンク経由でお願いします。
+    </p>
+  </header>
+
+  <dl class="contact-list">
+    {
+      items.map((item) => (
+        <div class="row">
+          <dt>{item.channel}</dt>
+          <dd>
+            <a
+              href={item.href}
+              target={item.external ? '_blank' : undefined}
+              rel={item.external ? 'noopener noreferrer' : undefined}
+            >
+              {item.href.replace(/^https?:\/\//, '').replace(/\/$/, '')}
+            </a>
+            <p class="detail">{item.detail}</p>
+          </dd>
+        </div>
+      ))
+    }
+  </dl>
+</BaseLayout>
+
+<style>
+  .back {
+    margin-bottom: var(--space-8);
+    font-size: 0.875rem;
+  }
+
+  .page-header {
+    margin-bottom: var(--space-12);
+  }
+
+  .eyebrow {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--fg-subtle);
+    margin: 0 0 var(--space-2);
+  }
+
+  .page-header h1 {
+    font-size: 2rem;
+    margin: 0 0 var(--space-4);
+  }
+
+  .lead {
+    font-size: 1.0625rem;
+    color: var(--fg);
+    max-width: 36rem;
+    margin: 0;
+  }
+
+  .contact-list {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  .row {
+    display: grid;
+    grid-template-columns: 9rem 1fr;
+    gap: var(--space-4);
+    padding: var(--space-4) 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .row:last-child {
+    border-bottom: none;
+  }
+
+  dt {
+    font-size: 0.875rem;
+    color: var(--fg-subtle);
+    font-weight: 500;
+  }
+
+  dd {
+    margin: 0;
+    font-size: 0.9375rem;
+  }
+
+  dd a {
+    word-break: break-all;
+  }
+
+  .detail {
+    margin: var(--space-2) 0 0;
+    color: var(--fg-muted);
+    font-size: 0.875rem;
+    line-height: 1.6;
+  }
+
+  @media (max-width: 560px) {
+    .row {
+      grid-template-columns: 1fr;
+      gap: var(--space-1);
+    }
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -38,13 +38,16 @@ const skillCategories = [
 const sections = [
   { label: 'Projects', href: '/projects/' },
   { label: 'Architecture Notes', href: '/notes/' },
+  { label: 'Playground', href: '/playground/' },
+  { label: 'OSS', href: '/oss/' },
+  { label: 'About', href: '/about/' },
+  { label: 'Contact', href: '/contact/' },
 ];
 
 const externalLinks = [
   { label: 'GitHub', href: 'https://github.com/cilly-yllic', external: true },
   { label: 'X', href: '#', external: true },
   { label: 'Resume', href: '#', external: true },
-  { label: 'Contact', href: 'mailto:yoshihiro.okuda@mooodone.com' },
 ];
 ---
 

--- a/src/pages/oss.astro
+++ b/src/pages/oss.astro
@@ -1,0 +1,92 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import StatusCard from '../components/StatusCard.astro';
+
+const items = [
+  {
+    title: 'Utility Libraries',
+    description:
+      '日々の TypeScript プロジェクトで再利用している小さなユーティリティ群 (date / collection / typed helper)。汎用化と公開準備中。',
+    status: 'Planned' as const,
+  },
+  {
+    title: 'ESLint Config',
+    description:
+      'Vue / Nuxt / Astro を横断して使える ESLint 設定プリセット。複数プロジェクトのコーディング規約を一本化するためのもの。',
+    status: 'Planned' as const,
+  },
+  {
+    title: 'Firebase Wrappers',
+    description:
+      'Firestore / Cloud Tasks / Auth を扱う際の薄いラッパー。型安全な query builder と reconciliation テンプレートを含む。',
+    status: 'Planned' as const,
+  },
+  {
+    title: 'Shared Internal Tooling',
+    description:
+      '社内向けに作っていた CLI / scaffolding / dev workflow tooling から、抽象度の高いものを切り出して公開予定。',
+    status: 'Planned' as const,
+  },
+];
+---
+
+<BaseLayout
+  title="OSS · cilly-yllic"
+  description="公開しているライブラリ・ツール。"
+>
+  <nav class="back">
+    <a href="/">← Home</a>
+  </nav>
+
+  <header class="page-header">
+    <p class="eyebrow">Open Source</p>
+    <h1>OSS</h1>
+    <p class="lead">
+      実装の中で「これは他のプロジェクトでも欲しい」と思ったものから、
+      抽象度を上げて公開しているライブラリ・ツール群。
+    </p>
+  </header>
+
+  <div class="card-list">
+    {
+      items.map((item) => (
+        <StatusCard
+          title={item.title}
+          description={item.description}
+          status={item.status}
+        />
+      ))
+    }
+  </div>
+</BaseLayout>
+
+<style>
+  .back {
+    margin-bottom: var(--space-8);
+    font-size: 0.875rem;
+  }
+
+  .page-header {
+    margin-bottom: var(--space-12);
+  }
+
+  .eyebrow {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--fg-subtle);
+    margin: 0 0 var(--space-2);
+  }
+
+  .page-header h1 {
+    font-size: 2rem;
+    margin: 0 0 var(--space-4);
+  }
+
+  .lead {
+    font-size: 1.0625rem;
+    color: var(--fg);
+    max-width: 36rem;
+    margin: 0;
+  }
+</style>

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -1,0 +1,98 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import StatusCard from '../components/StatusCard.astro';
+
+const demos = [
+  {
+    title: 'AI Task Tree Demo',
+    description:
+      'ゴール文を渡すと AI がタスクツリーを生成し、人手で編集 → reconcile される一連のフローをインタラクティブに見せる。',
+    status: 'Coming Soon' as const,
+  },
+  {
+    title: 'Realtime Presence Demo',
+    description:
+      '複数クライアントが同じドキュメントを編集しているときに、どのカーソルが誰のものかをリアルタイムで可視化する。',
+    status: 'Coming Soon' as const,
+  },
+  {
+    title: 'Firestore Sync Visualization',
+    description:
+      'Cloud SQL → Reconciliation Table → Cloud Tasks → Firestore の伝搬を、書き込みごとにタイムラインで可視化する。',
+    status: 'Coming Soon' as const,
+  },
+  {
+    title: 'OpenSearch Query Visualizer',
+    description:
+      'クエリを入力すると explain と分析機構のステップを段階的に表示し、Parent-Child / Nested / Flat の差を比較する。',
+    status: 'Coming Soon' as const,
+  },
+  {
+    title: 'Auth Flow Demo',
+    description:
+      'Firebase Auth + Custom Claims でテナント分離を実装したときの token 構造と RLS の動きを実際に試せる。',
+    status: 'Coming Soon' as const,
+  },
+];
+---
+
+<BaseLayout
+  title="Playground · cilly-yllic"
+  description="技術検証・実験の公開。インタラクティブに動かせる小さなデモ。"
+>
+  <nav class="back">
+    <a href="/">← Home</a>
+  </nav>
+
+  <header class="page-header">
+    <p class="eyebrow">Playground</p>
+    <h1>Experiments</h1>
+    <p class="lead">
+      本サイトの記事や Projects で扱った仕組みを、実際に手で動かせる形にした
+      小さなデモ。文章で説明するより、触ってもらった方が早いものを置く場所。
+    </p>
+  </header>
+
+  <div class="card-list">
+    {
+      demos.map((demo) => (
+        <StatusCard
+          title={demo.title}
+          description={demo.description}
+          status={demo.status}
+        />
+      ))
+    }
+  </div>
+</BaseLayout>
+
+<style>
+  .back {
+    margin-bottom: var(--space-8);
+    font-size: 0.875rem;
+  }
+
+  .page-header {
+    margin-bottom: var(--space-12);
+  }
+
+  .eyebrow {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--fg-subtle);
+    margin: 0 0 var(--space-2);
+  }
+
+  .page-header h1 {
+    font-size: 2rem;
+    margin: 0 0 var(--space-4);
+  }
+
+  .lead {
+    font-size: 1.0625rem;
+    color: var(--fg);
+    max-width: 36rem;
+    margin: 0;
+  }
+</style>


### PR DESCRIPTION
## Summary

- **新規 4 ページ**:
  - `/playground/` — 仕様書の 5 つの Demo 候補を `Coming Soon` ステータスで枠取り
  - `/oss/` — 4 つの掲載対象を `Planned` ステータスで枠取り
  - `/about/` — 興味領域 (5 項目) + 重視していること (5 項目、各短い解説付き)
  - `/contact/` — GitHub / X / Business Inquiry の 3 チャネル
- **`StatusCard` コンポーネント追加** — Available / Coming Soon / Planned / Archived の 4 ステータスを表示。Available の場合のみリンク化
- **Home `Sections` ブロックに 4 ページを追加** — Projects · Architecture Notes · Playground · OSS · About · Contact
- **Email 非公開化** — Contact からメールアドレスを削除し、Business Inquiry は `https://mooodone.com/` に誘導

## 完了条件

- [x] Playground ページ (枠組み + 候補リスト)
- [x] OSS ページ
- [x] About ページ
- [x] Contact ページ

## Test plan

- [ ] `npm run dev` で Home の Sections から 4 ページに辿れる
- [ ] 各ページの `← Home` で戻れる
- [ ] OS light / dark で見た目が崩れない
- [ ] Contact ページにメールアドレスが一切表示されない (grep で確認済み)
- [ ] Business Inquiry のリンクが `https://mooodone.com/` に外部遷移する

## 既知の制約

- **Playground / OSS のアイテム**: 全て Coming Soon / Planned。実体実装は別 Issue (将来) のスコープ
- **X のハンドル**: 未確定でプレースホルダ `#` のまま
- **Header ナビ**: 引き続き #8 のスコープ。本 PR では Home の Sections 拡張のみ

## 関連

Epic Issue #2
Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)