### PR TITLE
デザインシステム + ダークモード対応 #8

### DIFF
--- a/src/components/Mermaid.astro
+++ b/src/components/Mermaid.astro
@@ -45,21 +45,46 @@ const { code, caption } = Astro.props;
 <script>
   import mermaid from 'mermaid';
 
-  const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  function isDarkMode(): boolean {
+    const explicit = document.documentElement.dataset.theme;
+    if (explicit === 'dark') return true;
+    if (explicit === 'light') return false;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  }
 
-  mermaid.initialize({
-    startOnLoad: false,
-    theme: isDark ? 'dark' : 'neutral',
-    securityLevel: 'strict',
-    fontFamily: 'inherit',
-    flowchart: {
-      curve: 'basis',
-      htmlLabels: true,
-    },
-    themeVariables: {
-      fontSize: '14px',
-    },
+  function init() {
+    mermaid.initialize({
+      startOnLoad: false,
+      theme: isDarkMode() ? 'dark' : 'neutral',
+      securityLevel: 'strict',
+      fontFamily: 'inherit',
+      flowchart: {
+        curve: 'basis',
+        htmlLabels: true,
+      },
+      themeVariables: {
+        fontSize: '14px',
+      },
+    });
+  }
+
+  async function render() {
+    // Reset processed state so we can re-render on theme change.
+    document.querySelectorAll<HTMLElement>('pre.mermaid').forEach((el) => {
+      if (el.dataset.original) {
+        el.innerHTML = el.dataset.original;
+      } else if (el.textContent) {
+        el.dataset.original = el.textContent;
+      }
+      el.removeAttribute('data-processed');
+    });
+    init();
+    await mermaid.run({ querySelector: 'pre.mermaid' });
+  }
+
+  await render();
+
+  document.addEventListener('themechange', () => {
+    void render();
   });
-
-  await mermaid.run({ querySelector: 'pre.mermaid' });
 </script>

--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -1,0 +1,62 @@
+---
+const year = new Date().getFullYear();
+---
+
+<footer class="site-footer">
+  <div class="inner">
+    <p class="copyright">© {year} cilly-yllic</p>
+    <ul class="links">
+      <li>
+        <a href="https://github.com/cilly-yllic/cilly-yllic.github.io" target="_blank" rel="noopener noreferrer">
+          Source
+        </a>
+      </li>
+      <li>
+        <a href="https://github.com/cilly-yllic" target="_blank" rel="noopener noreferrer">
+          GitHub
+        </a>
+      </li>
+    </ul>
+  </div>
+</footer>
+
+<style>
+  .site-footer {
+    border-top: 1px solid var(--border);
+    margin-top: var(--space-16);
+  }
+
+  .inner {
+    max-width: var(--max-w-wide);
+    margin: 0 auto;
+    padding: var(--space-8) var(--space-6);
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--space-4);
+  }
+
+  .copyright {
+    margin: 0;
+    color: var(--fg-subtle);
+    font-size: 0.8125rem;
+  }
+
+  .links {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    gap: var(--space-4);
+  }
+
+  .links a {
+    font-size: 0.8125rem;
+    color: var(--fg-subtle);
+  }
+
+  .links a:hover {
+    color: var(--fg);
+  }
+</style>

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -1,0 +1,121 @@
+---
+import ThemeToggle from './ThemeToggle.astro';
+
+const nav = [
+  { label: 'Projects', href: '/projects/' },
+  { label: 'Notes', href: '/notes/' },
+  { label: 'Playground', href: '/playground/' },
+  { label: 'OSS', href: '/oss/' },
+  { label: 'About', href: '/about/' },
+  { label: 'Contact', href: '/contact/' },
+];
+
+const currentPath = Astro.url.pathname;
+
+function isActive(href: string) {
+  if (href === '/') return currentPath === '/';
+  return currentPath === href || currentPath.startsWith(href);
+}
+---
+
+<header class="site-header">
+  <div class="inner">
+    <a href="/" class="brand" aria-label="cilly-yllic, home">cilly-yllic</a>
+
+    <nav aria-label="Primary">
+      <ul>
+        {
+          nav.map((item) => (
+            <li>
+              <a
+                href={item.href}
+                class:list={['nav-link', { active: isActive(item.href) }]}
+                aria-current={isActive(item.href) ? 'page' : undefined}
+              >
+                {item.label}
+              </a>
+            </li>
+          ))
+        }
+      </ul>
+    </nav>
+
+    <div class="actions">
+      <ThemeToggle />
+    </div>
+  </div>
+</header>
+
+<style>
+  .site-header {
+    border-bottom: 1px solid var(--border);
+    background: var(--bg);
+  }
+
+  .inner {
+    max-width: var(--max-w-wide);
+    margin: 0 auto;
+    padding: var(--space-4) var(--space-6);
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: var(--space-6);
+  }
+
+  .brand {
+    color: var(--fg);
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 0.9375rem;
+    letter-spacing: -0.01em;
+  }
+
+  .brand:hover {
+    color: var(--link-hover);
+  }
+
+  nav ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-4);
+    justify-content: center;
+  }
+
+  .nav-link {
+    color: var(--fg-muted);
+    text-decoration: none;
+    font-size: 0.875rem;
+    padding: var(--space-1) 0;
+    border-bottom: 1px solid transparent;
+    transition: color 0.15s ease;
+  }
+
+  .nav-link:hover {
+    color: var(--fg);
+  }
+
+  .nav-link.active {
+    color: var(--fg);
+    border-bottom-color: var(--fg);
+  }
+
+  @media (max-width: 720px) {
+    .inner {
+      grid-template-columns: 1fr auto;
+      grid-template-rows: auto auto;
+      gap: var(--space-3);
+    }
+
+    nav {
+      grid-column: 1 / -1;
+      grid-row: 2;
+    }
+
+    nav ul {
+      justify-content: flex-start;
+    }
+  }
+</style>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,0 +1,99 @@
+---
+const modes = [
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+  { value: 'auto', label: 'Auto' },
+];
+---
+
+<div class="theme-toggle" role="radiogroup" aria-label="Theme">
+  {
+    modes.map((mode) => (
+      <button
+        type="button"
+        role="radio"
+        aria-checked="false"
+        data-theme-value={mode.value}
+      >
+        {mode.label}
+      </button>
+    ))
+  }
+</div>
+
+<style>
+  .theme-toggle {
+    display: inline-flex;
+    gap: 0;
+    padding: 2px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: var(--bg);
+  }
+
+  button {
+    appearance: none;
+    background: transparent;
+    border: 0;
+    padding: var(--space-1) var(--space-3);
+    font-size: 0.75rem;
+    color: var(--fg-subtle);
+    cursor: pointer;
+    border-radius: calc(var(--radius-md) - 2px);
+    line-height: 1.4;
+    letter-spacing: 0.02em;
+    transition:
+      background 0.15s ease,
+      color 0.15s ease;
+  }
+
+  button:hover {
+    color: var(--fg);
+  }
+
+  button[aria-checked='true'] {
+    background: var(--bg-elevated);
+    color: var(--fg);
+  }
+</style>
+
+<script is:inline>
+  (() => {
+    const KEY = 'theme';
+    const valid = ['light', 'dark', 'auto'];
+
+    function getStored() {
+      const v = localStorage.getItem(KEY);
+      return valid.includes(v) ? v : 'auto';
+    }
+
+    function apply(value) {
+      const root = document.documentElement;
+      if (value === 'auto') {
+        delete root.dataset.theme;
+      } else {
+        root.dataset.theme = value;
+      }
+      const buttons = document.querySelectorAll('[data-theme-value]');
+      buttons.forEach((btn) => {
+        btn.setAttribute('aria-checked', btn.dataset.themeValue === value ? 'true' : 'false');
+      });
+    }
+
+    function sync() {
+      apply(getStored());
+    }
+
+    sync();
+
+    document.addEventListener('click', (e) => {
+      const target = e.target.closest('[data-theme-value]');
+      if (!target) return;
+      const value = target.dataset.themeValue;
+      if (!valid.includes(value)) return;
+      localStorage.setItem(KEY, value);
+      apply(value);
+      document.dispatchEvent(new CustomEvent('themechange', { detail: { theme: value } }));
+    });
+  })();
+</script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,4 +1,9 @@
 ---
+import '../styles/tokens.css';
+import '../styles/base.css';
+import SiteHeader from '../components/SiteHeader.astro';
+import SiteFooter from '../components/SiteFooter.astro';
+
 interface Props {
   title?: string;
   description?: string;
@@ -40,137 +45,30 @@ const canonical = new URL(Astro.url.pathname, Astro.site).toString();
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImage} />
+
+    <script is:inline>
+      // Set theme before render to avoid FOUC.
+      (() => {
+        const v = localStorage.getItem('theme');
+        if (v === 'light' || v === 'dark') {
+          document.documentElement.dataset.theme = v;
+        }
+      })();
+    </script>
   </head>
   <body>
+    <SiteHeader />
     <main>
       <slot />
     </main>
+    <SiteFooter />
   </body>
 </html>
 
 <style is:global>
-  :root {
-    --bg: #ffffff;
-    --fg: #1a1a1a;
-    --fg-muted: #555555;
-    --fg-subtle: #888888;
-    --border: #e5e5e5;
-    --accent: #1a1a1a;
-    --link: #1a1a1a;
-    --link-hover: #000000;
-
-    --font-sans:
-      ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue',
-      Arial, 'Hiragino Sans', 'Hiragino Kaku Gothic ProN', Meiryo, sans-serif;
-    --font-mono:
-      ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono',
-      monospace;
-
-    --max-w: 720px;
-    --space-1: 0.25rem;
-    --space-2: 0.5rem;
-    --space-3: 0.75rem;
-    --space-4: 1rem;
-    --space-6: 1.5rem;
-    --space-8: 2rem;
-    --space-12: 3rem;
-    --space-16: 4rem;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    :root {
-      --bg: #0e0e10;
-      --fg: #ededed;
-      --fg-muted: #b5b5b5;
-      --fg-subtle: #7a7a7a;
-      --border: #27272a;
-      --accent: #ededed;
-      --link: #ededed;
-      --link-hover: #ffffff;
-    }
-  }
-
-  *,
-  *::before,
-  *::after {
-    box-sizing: border-box;
-  }
-
-  html {
-    -webkit-text-size-adjust: 100%;
-    text-rendering: optimizeLegibility;
-  }
-
-  body {
-    margin: 0;
-    background: var(--bg);
-    color: var(--fg);
-    font-family: var(--font-sans);
-    font-size: 16px;
-    line-height: 1.7;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-  }
-
   main {
     max-width: var(--max-w);
     margin: 0 auto;
-    padding: var(--space-16) var(--space-6);
-  }
-
-  h1,
-  h2,
-  h3 {
-    color: var(--fg);
-    font-weight: 600;
-    letter-spacing: -0.01em;
-    line-height: 1.3;
-  }
-
-  h1 {
-    font-size: 1.75rem;
-    margin: 0 0 var(--space-4);
-  }
-
-  h2 {
-    font-size: 1.05rem;
-    margin: 0 0 var(--space-4);
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: var(--fg-subtle);
-    font-weight: 500;
-  }
-
-  p {
-    margin: 0 0 var(--space-4);
-    color: var(--fg-muted);
-  }
-
-  a {
-    color: var(--link);
-    text-decoration: underline;
-    text-decoration-thickness: 1px;
-    text-underline-offset: 3px;
-    transition: color 0.15s ease;
-  }
-
-  a:hover {
-    color: var(--link-hover);
-  }
-
-  a:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 2px;
-    border-radius: 2px;
-  }
-
-  code {
-    font-family: var(--font-mono);
-    font-size: 0.92em;
-  }
-
-  ::selection {
-    background: var(--fg);
-    color: var(--bg);
+    padding: var(--space-12) var(--space-6) var(--space-16);
   }
 </style>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -38,10 +38,6 @@ const values = [
   title="About · cilly-yllic"
   description="エンジニアとしての関心領域、設計上重視していること。"
 >
-  <nav class="back">
-    <a href="/">← Home</a>
-  </nav>
-
   <header class="page-header">
     <p class="eyebrow">About</p>
     <h1>About me</h1>
@@ -73,11 +69,6 @@ const values = [
 </BaseLayout>
 
 <style>
-  .back {
-    margin-bottom: var(--space-8);
-    font-size: 0.875rem;
-  }
-
   .page-header {
     margin-bottom: var(--space-16);
   }

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -35,10 +35,6 @@ const items: ContactItem[] = [
   title="Contact · cilly-yllic"
   description="連絡先・業務委託の問い合わせ。"
 >
-  <nav class="back">
-    <a href="/">← Home</a>
-  </nav>
-
   <header class="page-header">
     <p class="eyebrow">Contact</p>
     <h1>Get in touch</h1>
@@ -70,11 +66,6 @@ const items: ContactItem[] = [
 </BaseLayout>
 
 <style>
-  .back {
-    margin-bottom: var(--space-8);
-    font-size: 0.875rem;
-  }
-
   .page-header {
     margin-bottom: var(--space-12);
   }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,15 +35,6 @@ const skillCategories = [
   },
 ];
 
-const sections = [
-  { label: 'Projects', href: '/projects/' },
-  { label: 'Architecture Notes', href: '/notes/' },
-  { label: 'Playground', href: '/playground/' },
-  { label: 'OSS', href: '/oss/' },
-  { label: 'About', href: '/about/' },
-  { label: 'Contact', href: '/contact/' },
-];
-
 const externalLinks = [
   { label: 'GitHub', href: 'https://github.com/cilly-yllic', external: true },
   { label: 'X', href: '#', external: true },
@@ -57,6 +48,5 @@ const externalLinks = [
     tagline="Full-cycle web engineer focused on scalable architecture, AI-integrated systems, and product-oriented development."
   />
   <Skills categories={skillCategories} />
-  <ExternalLinks title="Sections" links={sections} />
-  <ExternalLinks title="Links" links={externalLinks} />
+  <ExternalLinks title="Elsewhere" links={externalLinks} />
 </BaseLayout>

--- a/src/pages/notes/[category]/[slug].astro
+++ b/src/pages/notes/[category]/[slug].astro
@@ -28,10 +28,6 @@ const updated = note.data.updatedAt?.toISOString().slice(0, 10);
   title={`${note.data.title} · Architecture Notes`}
   description={note.data.description}
 >
-  <nav class="back">
-    <a href={`/notes/${note.data.category}/`}>← {categoryTitle}</a>
-  </nav>
-
   <article class="article">
     <header class="article-header">
       <p class="eyebrow">{categoryTitle}</p>
@@ -50,11 +46,6 @@ const updated = note.data.updatedAt?.toISOString().slice(0, 10);
 </BaseLayout>
 
 <style>
-  .back {
-    margin-bottom: var(--space-8);
-    font-size: 0.875rem;
-  }
-
   .article-header {
     margin-bottom: var(--space-12);
     padding-bottom: var(--space-8);
@@ -171,15 +162,24 @@ const updated = note.data.updatedAt?.toISOString().slice(0, 10);
     font-style: normal;
   }
 
-  /* Shiki dual theme: switch by prefers-color-scheme */
+  /* Shiki dual theme: follow OS by default, override by data-theme */
   @media (prefers-color-scheme: dark) {
-    .prose .astro-code,
-    .prose .astro-code span {
+    :root:not([data-theme='light']) .prose .astro-code,
+    :root:not([data-theme='light']) .prose .astro-code span {
       color: var(--shiki-dark) !important;
       background-color: var(--shiki-dark-bg) !important;
       font-style: var(--shiki-dark-font-style) !important;
       font-weight: var(--shiki-dark-font-weight) !important;
       text-decoration: var(--shiki-dark-text-decoration) !important;
     }
+  }
+
+  :root[data-theme='dark'] .prose .astro-code,
+  :root[data-theme='dark'] .prose .astro-code span {
+    color: var(--shiki-dark) !important;
+    background-color: var(--shiki-dark-bg) !important;
+    font-style: var(--shiki-dark-font-style) !important;
+    font-weight: var(--shiki-dark-font-weight) !important;
+    text-decoration: var(--shiki-dark-text-decoration) !important;
   }
 </style>

--- a/src/pages/notes/[category]/index.astro
+++ b/src/pages/notes/[category]/index.astro
@@ -32,10 +32,6 @@ const sorted = notes.sort(
   title={`${categoryTitle} · Architecture Notes`}
   description={`${categoryTitle} カテゴリの記事一覧。`}
 >
-  <nav class="back">
-    <a href="/notes/">← Notes</a>
-  </nav>
-
   <header class="page-header">
     <p class="eyebrow">Architecture Notes</p>
     <h1>{categoryTitle}</h1>
@@ -62,11 +58,6 @@ const sorted = notes.sort(
 </BaseLayout>
 
 <style>
-  .back {
-    margin-bottom: var(--space-8);
-    font-size: 0.875rem;
-  }
-
   .page-header {
     margin-bottom: var(--space-12);
   }

--- a/src/pages/notes/index.astro
+++ b/src/pages/notes/index.astro
@@ -22,10 +22,6 @@ function countByCategory(slug: CategorySlug) {
   title="Architecture Notes · cilly-yllic"
   description="技術思想・設計思想に関する記事。Firebase / GCP、OpenSearch、Frontend Architecture、AI Development、Engineering Philosophy。"
 >
-  <nav class="back">
-    <a href="/">← Home</a>
-  </nav>
-
   <header class="page-header">
     <p class="eyebrow">Architecture Notes</p>
     <h1>Notes</h1>
@@ -68,11 +64,6 @@ function countByCategory(slug: CategorySlug) {
 </BaseLayout>
 
 <style>
-  .back {
-    margin-bottom: var(--space-8);
-    font-size: 0.875rem;
-  }
-
   .page-header {
     margin-bottom: var(--space-16);
   }

--- a/src/pages/oss.astro
+++ b/src/pages/oss.astro
@@ -34,10 +34,6 @@ const items = [
   title="OSS · cilly-yllic"
   description="公開しているライブラリ・ツール。"
 >
-  <nav class="back">
-    <a href="/">← Home</a>
-  </nav>
-
   <header class="page-header">
     <p class="eyebrow">Open Source</p>
     <h1>OSS</h1>
@@ -61,11 +57,6 @@ const items = [
 </BaseLayout>
 
 <style>
-  .back {
-    margin-bottom: var(--space-8);
-    font-size: 0.875rem;
-  }
-
   .page-header {
     margin-bottom: var(--space-12);
   }

--- a/src/pages/playground.astro
+++ b/src/pages/playground.astro
@@ -40,10 +40,6 @@ const demos = [
   title="Playground · cilly-yllic"
   description="技術検証・実験の公開。インタラクティブに動かせる小さなデモ。"
 >
-  <nav class="back">
-    <a href="/">← Home</a>
-  </nav>
-
   <header class="page-header">
     <p class="eyebrow">Playground</p>
     <h1>Experiments</h1>
@@ -67,11 +63,6 @@ const demos = [
 </BaseLayout>
 
 <style>
-  .back {
-    margin-bottom: var(--space-8);
-    font-size: 0.875rem;
-  }
-
   .page-header {
     margin-bottom: var(--space-12);
   }

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -73,10 +73,6 @@ const decisions = [
   title="Projects · cilly-yllic"
   description="Projects showcase. Main: Task Tree — an AI-augmented hierarchical task system built on Data Connect + Firestore + Cloud Tasks reconciliation."
 >
-  <nav class="back">
-    <a href="/">← Home</a>
-  </nav>
-
   <header class="page-header">
     <p class="eyebrow">Projects</p>
     <h1>Task Tree</h1>
@@ -195,11 +191,6 @@ const decisions = [
 </BaseLayout>
 
 <style>
-  .back {
-    margin-bottom: var(--space-8);
-    font-size: 0.875rem;
-  }
-
   .page-header {
     margin-bottom: var(--space-16);
   }

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1,0 +1,100 @@
+/* Reset */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  -webkit-text-size-adjust: 100%;
+  text-rendering: optimizeLegibility;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-base);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Typography */
+h1,
+h2,
+h3,
+h4 {
+  color: var(--fg);
+  font-weight: 600;
+  letter-spacing: var(--letter-spacing-tight);
+  line-height: var(--line-height-tight);
+}
+
+h1 {
+  font-size: 1.75rem;
+  margin: 0 0 var(--space-4);
+}
+
+h2 {
+  font-size: 1.05rem;
+  margin: 0 0 var(--space-4);
+  text-transform: uppercase;
+  letter-spacing: var(--letter-spacing-wide);
+  color: var(--fg-subtle);
+  font-weight: 500;
+}
+
+p {
+  margin: 0 0 var(--space-4);
+  color: var(--fg-muted);
+}
+
+a {
+  color: var(--link);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+  transition: color 0.15s ease;
+}
+
+a:hover {
+  color: var(--link-hover);
+}
+
+a:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+button {
+  font-family: inherit;
+}
+
+button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+code {
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+}
+
+::selection {
+  background: var(--fg);
+  color: var(--bg);
+}
+
+/* Reduce animation when user prefers */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,92 @@
+/*
+ * Design Tokens
+ *
+ * 3 つのテーマモード:
+ *   - data-theme="light" → ライト固定
+ *   - data-theme="dark"  → ダーク固定
+ *   - data-theme なし     → OS の prefers-color-scheme に追従
+ */
+
+:root {
+  color-scheme: light;
+
+  /* Surface */
+  --bg: #ffffff;
+  --bg-elevated: #f7f7f8;
+  --border: #e5e5e5;
+  --border-strong: #c8c8c8;
+
+  /* Text */
+  --fg: #1a1a1a;
+  --fg-muted: #555555;
+  --fg-subtle: #888888;
+
+  /* Accent */
+  --accent: #1a1a1a;
+  --link: #1a1a1a;
+  --link-hover: #000000;
+
+  /* Typography */
+  --font-sans:
+    ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue',
+    Arial, 'Hiragino Sans', 'Hiragino Kaku Gothic ProN', Meiryo, sans-serif;
+  --font-mono:
+    ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono',
+    monospace;
+  --font-size-base: 16px;
+  --line-height-base: 1.7;
+  --line-height-tight: 1.3;
+  --line-height-prose: 1.8;
+  --letter-spacing-tight: -0.015em;
+  --letter-spacing-wide: 0.08em;
+  --letter-spacing-wider: 0.12em;
+
+  /* Layout */
+  --max-w: 720px;
+  --max-w-wide: 960px;
+
+  /* Spacing scale */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+
+  /* Radius */
+  --radius-sm: 3px;
+  --radius-md: 6px;
+}
+
+/* Dark theme tokens — applied via both OS preference (when no override) and explicit choice */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) {
+    color-scheme: dark;
+    --bg: #0e0e10;
+    --bg-elevated: #18181b;
+    --border: #27272a;
+    --border-strong: #3f3f46;
+    --fg: #ededed;
+    --fg-muted: #b5b5b5;
+    --fg-subtle: #7a7a7a;
+    --accent: #ededed;
+    --link: #ededed;
+    --link-hover: #ffffff;
+  }
+}
+
+:root[data-theme='dark'] {
+  color-scheme: dark;
+  --bg: #0e0e10;
+  --bg-elevated: #18181b;
+  --border: #27272a;
+  --border-strong: #3f3f46;
+  --fg: #ededed;
+  --fg-muted: #b5b5b5;
+  --fg-subtle: #7a7a7a;
+  --accent: #ededed;
+  --link: #ededed;
+  --link-hover: #ffffff;
+}


### PR DESCRIPTION
## Summary

### トークン分離
- `src/styles/tokens.css` — Color / Typography / Layout / Spacing / Radius の CSS 変数
- `src/styles/base.css` — Reset / 基本タイポ / `a` / `button` / `prefers-reduced-motion`
- `BaseLayout` から `import` で読み込み (インラインの `<style is:global>` を撤去)

### テーマシステム (3 モード)
- `light` / `dark` / `auto` (デフォルト = OS 追従)
- `<html data-theme="...">` 属性 + `localStorage` 永続化
- `<head>` の inline script で描画前に属性を付与 (FOUC 防止)
- CSS 適用: `:root` (light 既定) + `@media (prefers-color-scheme: dark) :root:not([data-theme="light"])` + `:root[data-theme="dark"]`

### 共通レイアウト
- `SiteHeader` — ブランド名 + 6 ナビリンク + `ThemeToggle`、`aria-current` で現在ページ明示、720px 以下で 2 段組
- `SiteFooter` — Copyright + Source / GitHub
- `ThemeToggle` — radiogroup 風の 3 ボタン、`themechange` カスタムイベント発火

### 連動アップデート
- **Mermaid** — `data-theme` を参照してテーマ判定 + `themechange` で再レンダリング
- **Shiki (Notes 記事)** — `data-theme` オーバーライドに対応 (OS dark でもユーザーが light 指定なら light を維持)

### ページ整理
- 各ページの `← Home` / `← Notes` / `← <Category>` を削除 (Header が普遍ナビ)
- Home の `Sections` ブロックを削除 (Header と重複)
- Home の `Links` → `Elsewhere` に名称変更

## 完了条件

- [x] カラートークン (light / dark) → `tokens.css`
- [x] タイポグラフィ (見出し / 本文 / コード) → `tokens.css` + `base.css`
- [x] レイアウトコンポーネント (Header / Footer / Container) → `SiteHeader` / `SiteFooter` / `<main>` max-width
- [x] ダークモード切替 (or システム連動) → 両対応 (`auto` がシステム連動)
- [x] フォーカスリング・アクセシビリティ → `:focus-visible` / `aria-current` / `role="radiogroup"` / `prefers-reduced-motion`

## Test plan

- [ ] Header の各リンクが全ページから機能する
- [ ] 現在ページのナビリンクが下線 + `aria-current="page"`
- [ ] テーマトグルで Light / Dark / Auto を切り替えるとリロード後も保持される
- [ ] OS dark で Auto を選ぶと dark になり、Light を選ぶと light になる
- [ ] Projects ページの Mermaid 図がテーマ切替時に再描画される
- [ ] Notes 記事のコードハイライトがテーマに追従する
- [ ] 720px 以下で Header ナビが折りたたまれる
- [ ] FOUC が発生しない (リロード時に瞬間的にライトテーマが見えない)

## 関連

Epic Issue #2
Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)