### PR TITLE
Release: 記事・OSS カード化と興味タグ色分け

### DIFF
--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -7,72 +7,151 @@ interface Props {
   category: CategorySlug;
   publishedAt: Date;
   href: string;
+  image?: string;
+  imageAlt?: string;
   showCategory?: boolean;
 }
 
-const { title, description, category, publishedAt, href, showCategory = true } =
-  Astro.props;
+const {
+  title,
+  description,
+  category,
+  publishedAt,
+  href,
+  image,
+  imageAlt = '',
+  showCategory = true,
+} = Astro.props;
 
 const categoryTitle = CATEGORIES.find((c) => c.slug === category)?.title ?? category;
 const date = publishedAt.toISOString().slice(0, 10);
 ---
 
 <article class="card">
-  <a href={href} class="title-link">
-    <h3>{title}</h3>
+  <a href={href} class="card__link">
+    {
+      image ? (
+        <div class="card__media">
+          <img src={image} alt={imageAlt} loading="lazy" decoding="async" />
+        </div>
+      ) : (
+        <div class="card__media card__media--placeholder">
+          <span class="card__placeholder-label">{categoryTitle}</span>
+        </div>
+      )
+    }
+    <div class="card__body">
+      <h3 class="card__title">{title}</h3>
+      <p class="card__desc">{description}</p>
+      <div class="card__meta">
+        <time datetime={date}>{date}</time>
+        {showCategory && <span class="card__category">{categoryTitle}</span>}
+      </div>
+    </div>
   </a>
-  <p class="description">{description}</p>
-  <div class="meta">
-    <time datetime={date}>{date}</time>
-    {showCategory && <span class="category">{categoryTitle}</span>}
-  </div>
 </article>
 
 <style>
   .card {
-    padding: var(--space-6) 0;
+    height: 100%;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+    background: var(--bg);
+    transition: border-color 0.2s ease;
+  }
+
+  .card:hover {
+    border-color: var(--border-strong);
+  }
+
+  .card__link {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    text-decoration: none;
+    color: inherit;
+  }
+
+  .card__media {
+    aspect-ratio: 16 / 9;
+    overflow: hidden;
+    background: var(--bg-elevated);
     border-bottom: 1px solid var(--border);
   }
 
-  .card:last-child {
-    border-bottom: none;
+  .card__media img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.4s ease;
   }
 
-  .title-link {
-    text-decoration: none;
+  .card:hover .card__media img {
+    transform: scale(1.03);
+  }
+
+  /* 画像がない記事用のプレースホルダー（画像ありカードと同じ 16:9 領域） */
+  .card__media--placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--bg-elevated);
+    background-image: radial-gradient(var(--border) 1.2px, transparent 1.2px);
+    background-size: 14px 14px;
+  }
+
+  .card__placeholder-label {
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: var(--letter-spacing-wide);
+    color: var(--fg-subtle);
+    background: var(--bg-elevated);
+    padding: var(--space-1) var(--space-2);
+    border-radius: var(--radius-sm);
+  }
+
+  .card__body {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    padding: var(--space-4);
+  }
+
+  .card__title {
+    margin: 0 0 var(--space-2);
+    font-size: 1rem;
+    font-weight: 600;
     color: var(--fg);
+    text-transform: none;
+    letter-spacing: -0.01em;
+    line-height: 1.4;
   }
 
-  .title-link:hover h3 {
+  .card__link:hover .card__title {
     text-decoration: underline;
     text-decoration-thickness: 1px;
     text-underline-offset: 4px;
   }
 
-  h3 {
-    margin: 0 0 var(--space-2);
-    font-size: 1.0625rem;
-    font-weight: 600;
-    color: var(--fg);
-    text-transform: none;
-    letter-spacing: -0.01em;
-  }
-
-  .description {
-    margin: 0 0 var(--space-3);
+  .card__desc {
+    margin: 0 0 var(--space-4);
     color: var(--fg-muted);
-    font-size: 0.9375rem;
+    font-size: 0.875rem;
     line-height: 1.6;
   }
 
-  .meta {
+  .card__meta {
+    margin-top: auto;
     display: flex;
     gap: var(--space-4);
-    font-size: 0.8125rem;
+    font-size: 0.75rem;
     color: var(--fg-subtle);
   }
 
-  .meta time {
+  .card__meta time {
     font-variant-numeric: tabular-nums;
   }
 </style>

--- a/src/components/OssCard.astro
+++ b/src/components/OssCard.astro
@@ -1,0 +1,162 @@
+---
+type Status = 'Available' | 'Coming Soon' | 'Planned' | 'Archived';
+
+interface Props {
+  title: string;
+  description: string;
+  status: Status;
+  href?: string;
+}
+
+const { title, description, status, href } = Astro.props;
+const isInteractive = !!href && status === 'Available';
+
+// href からサービス種別を判定してアイコンを出し分ける
+function iconType(url?: string): 'github' | 'npm' | 'generic' {
+  if (!url) return 'generic';
+  if (url.includes('github.com')) return 'github';
+  if (url.includes('npmjs.com') || url.includes('npmjs.org')) return 'npm';
+  return 'generic';
+}
+
+const icon = iconType(href);
+const iconLabel = icon === 'github' ? 'GitHub' : icon === 'npm' ? 'npm' : 'Link';
+const statusClass = `status-${status.replace(/\s+/g, '-').toLowerCase()}`;
+const Tag = isInteractive ? 'a' : 'div';
+---
+
+<article class="card">
+  <Tag
+    class="card__link"
+    href={isInteractive ? href : undefined}
+    target={isInteractive ? '_blank' : undefined}
+    rel={isInteractive ? 'noopener noreferrer' : undefined}
+  >
+    <div class="card__media">
+      <span class="card__icon" aria-label={iconLabel} role="img">
+        {
+          icon === 'github' && (
+            <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+            </svg>
+          )
+        }
+        {
+          icon === 'npm' && (
+            <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M1.763 0C.786 0 0 .786 0 1.763v20.474C0 23.214.786 24 1.763 24h20.474c.977 0 1.763-.786 1.763-1.763V1.763C24 .786 23.214 0 22.237 0zM5.13 5.323l13.837.019-.009 13.836h-3.464l.01-10.382h-3.456L12.04 19.17H5.113z" />
+            </svg>
+          )
+        }
+        {
+          icon === 'generic' && (
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+              <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+            </svg>
+          )
+        }
+      </span>
+    </div>
+    <div class="card__body">
+      <h3 class="card__title">{title}</h3>
+      <p class="card__desc">{description}</p>
+      <p class:list={['card__status', statusClass]}>{status}</p>
+    </div>
+  </Tag>
+</article>
+
+<style>
+  .card {
+    height: 100%;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+    background: var(--bg);
+    transition: border-color 0.2s ease;
+  }
+
+  .card:hover {
+    border-color: var(--border-strong);
+  }
+
+  .card__link {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    text-decoration: none;
+    color: inherit;
+  }
+
+  .card__media {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    aspect-ratio: 16 / 9;
+    background-color: var(--bg-elevated);
+    background-image: radial-gradient(var(--border) 1.2px, transparent 1.2px);
+    background-size: 14px 14px;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .card__icon {
+    display: inline-flex;
+    color: var(--fg-muted);
+    transition:
+      color 0.2s ease,
+      transform 0.3s ease;
+  }
+
+  .card__icon svg {
+    width: 3rem;
+    height: 3rem;
+  }
+
+  a.card__link:hover .card__icon {
+    color: var(--fg);
+    transform: scale(1.06);
+  }
+
+  .card__body {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    padding: var(--space-4);
+  }
+
+  .card__title {
+    margin: 0 0 var(--space-2);
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--fg);
+    text-transform: none;
+    letter-spacing: -0.01em;
+    line-height: 1.4;
+    word-break: break-word;
+  }
+
+  a.card__link:hover .card__title {
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 4px;
+  }
+
+  .card__desc {
+    margin: 0 0 var(--space-4);
+    color: var(--fg-muted);
+    font-size: 0.875rem;
+    line-height: 1.6;
+  }
+
+  .card__status {
+    margin: auto 0 0;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fg-subtle);
+  }
+
+  .status-available {
+    color: var(--fg);
+  }
+</style>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -20,6 +20,16 @@ const interests = [
 
 ];
 
+// 興味タグの色（index 順に割り当て）。color-mix でテーマに馴染ませる
+const tagColors = [
+  '#1c7ed6', // blue
+  '#0ca678', // teal
+  '#7048e8', // violet
+  '#e8590c', // orange
+  '#2f9e44', // green
+  '#e64980', // pink
+];
+
 const values = [
   
   {
@@ -91,8 +101,14 @@ const values = [
   </header>
 
   <Section title="興味領域">
-    <ul class="bullet-list">
-      {interests.map((item) => <li>{item}</li>)}
+    <ul class="tag-list">
+      {
+        interests.map((item, i) => (
+          <li class="tag" style={`--tag: ${tagColors[i % tagColors.length]}`}>
+            {item}
+          </li>
+        ))
+      }
     </ul>
   </Section>
 
@@ -135,18 +151,23 @@ const values = [
     margin: 0;
   }
 
-  .bullet-list {
+  .tag-list {
     list-style: none;
     padding: 0;
     margin: 0;
     display: flex;
     flex-wrap: wrap;
-    gap: var(--space-4) var(--space-6);
+    gap: var(--space-2) var(--space-3);
   }
 
-  .bullet-list li {
-    font-size: 0.9375rem;
-    color: var(--fg);
+  .tag {
+    font-size: 0.8125rem;
+    line-height: 1.5;
+    padding: var(--space-1) var(--space-3);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--tag) 12%, var(--bg));
+    border: 1px solid color-mix(in srgb, var(--tag) 32%, transparent);
+    color: color-mix(in srgb, var(--tag), var(--fg) 28%);
   }
 
   .values {

--- a/src/pages/notes/[category]/index.astro
+++ b/src/pages/notes/[category]/index.astro
@@ -26,6 +26,12 @@ const notes = await getCollection(
 const sorted = notes.sort(
   (a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime(),
 );
+
+// 本文 markdown から最初の画像（![alt](src)）を取り出す
+function firstImage(body?: string) {
+  const m = body?.match(/!\[([^\]]*)\]\(([^)\s]+)/);
+  return m ? { src: m[2], alt: m[1] } : null;
+}
 ---
 
 <BaseLayout
@@ -42,16 +48,21 @@ const sorted = notes.sort(
       sorted.length === 0 ? (
         <p class="empty">このカテゴリにはまだ記事がありません。</p>
       ) : (
-        sorted.map((note) => (
-          <ArticleCard
-            title={note.data.title}
-            description={note.data.description}
-            category={note.data.category}
-            publishedAt={note.data.publishedAt}
-            href={`/notes/${note.id}/`}
-            showCategory={false}
-          />
-        ))
+        sorted.map((note) => {
+          const img = firstImage(note.body);
+          return (
+            <ArticleCard
+              title={note.data.title}
+              description={note.data.description}
+              category={note.data.category}
+              publishedAt={note.data.publishedAt}
+              href={`/notes/${note.id}/`}
+              image={img?.src}
+              imageAlt={img?.alt}
+              showCategory={false}
+            />
+          );
+        })
       )
     }
   </div>
@@ -73,6 +84,12 @@ const sorted = notes.sort(
   .page-header h1 {
     font-size: 1.75rem;
     margin: 0;
+  }
+
+  .card-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: var(--space-4);
   }
 
   .empty {

--- a/src/pages/notes/index.astro
+++ b/src/pages/notes/index.astro
@@ -18,6 +18,12 @@ function entryHref(id: string) {
 function countByCategory(slug: CategorySlug) {
   return allNotes.filter((n) => n.data.category === slug).length;
 }
+
+// 本文 markdown から最初の画像（![alt](src)）を取り出す
+function firstImage(body?: string) {
+  const m = body?.match(/!\[([^\]]*)\]\(([^)\s]+)/);
+  return m ? { src: m[2], alt: m[1] } : null;
+}
 ---
 
 <BaseLayout
@@ -61,15 +67,20 @@ function countByCategory(slug: CategorySlug) {
     <h2>All Articles</h2>
     <div class="card-list">
       {
-        sorted.map((note) => (
-          <ArticleCard
-            title={note.data.title}
-            description={note.data.description}
-            category={note.data.category}
-            publishedAt={note.data.publishedAt}
-            href={entryHref(note.id)}
-          />
-        ))
+        sorted.map((note) => {
+          const img = firstImage(note.body);
+          return (
+            <ArticleCard
+              title={note.data.title}
+              description={note.data.description}
+              category={note.data.category}
+              publishedAt={note.data.publishedAt}
+              href={entryHref(note.id)}
+              image={img?.src}
+              imageAlt={img?.alt}
+            />
+          );
+        })
       }
     </div>
   </section>
@@ -118,6 +129,12 @@ function countByCategory(slug: CategorySlug) {
 
   .categories {
     margin-bottom: var(--space-16);
+  }
+
+  .card-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: var(--space-4);
   }
 
   .category-list {

--- a/src/pages/oss.astro
+++ b/src/pages/oss.astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { Image } from 'astro:assets';
-import StatusCard from '../components/StatusCard.astro';
+import OssCard from '../components/OssCard.astro';
 import heroImage from '../assets/life/gallery/013.jpg';
 
 interface OssItem {
@@ -61,7 +61,7 @@ const items: OssItem[] = [
   <div class="card-list">
     {
       items.map((item) => (
-        <StatusCard
+        <OssCard
           title={item.title}
           description={item.description}
           status={item.status}
@@ -111,5 +111,11 @@ const items: OssItem[] = [
     color: var(--fg);
     max-width: 36rem;
     margin: 0;
+  }
+
+  .card-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: var(--space-4);
   }
 </style>


### PR DESCRIPTION
develop の変更を main へ反映します。

- 記事一覧 / OSS 一覧のカード化（GitHub・npm アイコン出し分け）
- 記事カードは本文画像 or プレースホルダーで高さ統一
- About 興味領域を色分けタグ化

PR #22 を含みます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)