### PR TITLE
コメント機能: giscus 導入 + 記事一覧にコメント/いいね数表示

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -9,6 +9,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  discussions: read
 
 concurrency:
   group: 'pages'
@@ -34,6 +35,9 @@ jobs:
         run: npm run build
         env:
           PUBLIC_GA_MEASUREMENT_ID: ${{ vars.PUBLIC_GA_MEASUREMENT_ID }}
+          # 記事一覧のコメント数・いいね数を取得するための自リポジトリ用トークン。
+          # Secrets 登録は不要（Actions が github.token を自動発行）。
+          GISCUS_GITHUB_TOKEN: ${{ github.token }}
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/public/giscus/dark.css
+++ b/public/giscus/dark.css
@@ -1,0 +1,25 @@
+/*
+ * giscus 用カスタムテーマ（Dark）。
+ * 公式 dark テーマを土台に、ディスカッション本体のリアクションバーだけ控えめにする。
+ * 調整内容は light.css と揃える。
+ */
+@import url("https://giscus.app/themes/dark.css");
+
+/* リアクションバーを小さく・右寄せ・余白圧縮（本文直後の主張を抑える） */
+.gsc-reactions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  font-size: 0.82em;
+  margin: 0 0 0.5rem;
+}
+
+.gsc-reactions-count {
+  margin-bottom: 0.25rem;
+  opacity: 0.85;
+}
+
+/* 絵文字ボタン列も詰める */
+.gsc-direct-reaction-buttons {
+  gap: 0.15rem;
+}

--- a/public/giscus/light.css
+++ b/public/giscus/light.css
@@ -1,0 +1,25 @@
+/*
+ * giscus 用カスタムテーマ（Light）。
+ * 公式 light テーマを土台に、ディスカッション本体のリアクションバーだけ控えめにする。
+ * theme を URL 指定すると giscus の iframe 内でこの CSS が読まれる。
+ */
+@import url("https://giscus.app/themes/light.css");
+
+/* リアクションバーを小さく・右寄せ・余白圧縮（本文直後の主張を抑える） */
+.gsc-reactions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  font-size: 0.82em;
+  margin: 0 0 0.5rem;
+}
+
+.gsc-reactions-count {
+  margin-bottom: 0.25rem;
+  opacity: 0.85;
+}
+
+/* 絵文字ボタン列も詰める */
+.gsc-direct-reaction-buttons {
+  gap: 0.15rem;
+}

--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -1,5 +1,6 @@
 ---
 import { CATEGORIES, type CategorySlug } from '../content.config';
+import DiscussionStats from './DiscussionStats.astro';
 
 interface Props {
   title: string;
@@ -10,6 +11,10 @@ interface Props {
   image?: string;
   imageAlt?: string;
   showCategory?: boolean;
+  /** コメント数（ビルド時に GitHub Discussions から取得。未取得なら undefined） */
+  commentCount?: number;
+  /** いいね(リアクション)数。未取得なら undefined */
+  reactionCount?: number;
 }
 
 const {
@@ -21,6 +26,8 @@ const {
   image,
   imageAlt = '',
   showCategory = true,
+  commentCount,
+  reactionCount,
 } = Astro.props;
 
 const categoryTitle = CATEGORIES.find((c) => c.slug === category)?.title ?? category;
@@ -46,6 +53,7 @@ const date = publishedAt.toISOString().slice(0, 10);
       <div class="card__meta">
         <time datetime={date}>{date}</time>
         {showCategory && <span class="card__category">{categoryTitle}</span>}
+        <DiscussionStats comments={commentCount} reactions={reactionCount} class="card__stats" />
       </div>
     </div>
   </a>
@@ -153,5 +161,10 @@ const date = publishedAt.toISOString().slice(0, 10);
 
   .card__meta time {
     font-variant-numeric: tabular-nums;
+  }
+
+  /* カウントは右端へ寄せる */
+  .card__stats {
+    margin-left: auto;
   }
 </style>

--- a/src/components/DiscussionStats.astro
+++ b/src/components/DiscussionStats.astro
@@ -1,0 +1,64 @@
+---
+// 記事カード等に出すコメント数・いいね(リアクション)数のバッジ。
+// 値が undefined の項目は描画しない（未設定・未取得時は何も出さない）。
+interface Props {
+  comments?: number;
+  reactions?: number;
+  class?: string;
+}
+
+const { comments, reactions, class: className } = Astro.props;
+
+const hasComments = typeof comments === 'number';
+const hasReactions = typeof reactions === 'number';
+---
+
+{
+  (hasComments || hasReactions) && (
+    <span class:list={['stats', className]}>
+      {hasReactions && (
+        <span class="stats__item" aria-label={`いいね ${reactions} 件`}>
+          <svg class="stats__icon" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+            <path
+              fill="currentColor"
+              d="M8 14.25 6.84 13.2C3.4 10.1 1.5 8.38 1.5 6.25 1.5 4.51 2.86 3.15 4.6 3.15c.98 0 1.92.46 2.5 1.18l.9 1.1.9-1.1a3.2 3.2 0 0 1 2.5-1.18c1.74 0 3.1 1.36 3.1 3.1 0 2.13-1.9 3.85-5.34 6.96L8 14.25Z"
+            />
+          </svg>
+          <span class="stats__count">{reactions}</span>
+        </span>
+      )}
+      {hasComments && (
+        <span class="stats__item" aria-label={`コメント ${comments} 件`}>
+          <svg class="stats__icon" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+            <path
+              fill="currentColor"
+              d="M2 3.5A1.5 1.5 0 0 1 3.5 2h9A1.5 1.5 0 0 1 14 3.5v6a1.5 1.5 0 0 1-1.5 1.5H6.7L4 13.5c-.66.55-1 .31-1-.5V11H3.5A1.5 1.5 0 0 1 2 9.5v-6Z"
+            />
+          </svg>
+          <span class="stats__count">{comments}</span>
+        </span>
+      )}
+    </span>
+  )
+}
+
+<style>
+  .stats {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-3);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .stats__item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25em;
+  }
+
+  .stats__icon {
+    width: 0.9em;
+    height: 0.9em;
+    flex: none;
+  }
+</style>

--- a/src/components/Giscus.astro
+++ b/src/components/Giscus.astro
@@ -1,0 +1,209 @@
+---
+// 記事ページ専用のコメント欄（giscus / GitHub Discussions）。
+//
+// ── mapping に 'specific' を採用した理由 ────────────────────────────────
+// 候補のうち pathname / url / og:title / title はいずれも「URL や見出し」を
+// キーにするため、後でパーマリンクや記事タイトルを変えると過去のコメントが
+// 紐付かなくなる。specific は任意の固定文字列(term)をキーにできるので、
+// ここでは URL から独立した note.id ("<category>/<slug>") を term に渡す。
+// これにより URL 変更・タイトル変更のどちらにも強い紐付けになる。
+//
+// ── 設計方針 ──────────────────────────────────────────────────────────
+// ・設定値は src/config/giscus.ts に集約。props で各項目を上書きできる。
+// ・読み込みは IntersectionObserver による遅延ロード（本文表示を優先）。
+// ・テーマはサイトの data-theme と同期し、リロード不要で切り替わる。
+import {
+  GISCUS_CONFIG,
+  GISCUS_ORIGIN,
+  GISCUS_SCRIPT_SRC,
+  isGiscusConfigured,
+  type GiscusConfig,
+} from '../config/giscus';
+
+interface Props extends Partial<GiscusConfig> {
+  /** Discussion を一意に紐付ける term。通常は note.id を渡す。 */
+  term: string;
+  /** ルート要素へ付与する追加クラス */
+  class?: string;
+}
+
+const { term, class: className, ...overrides } = Astro.props;
+
+// 既定値(GISCUS_CONFIG)を props で部分的に上書き。
+const config: GiscusConfig = {
+  repo: overrides.repo ?? GISCUS_CONFIG.repo,
+  repoId: overrides.repoId ?? GISCUS_CONFIG.repoId,
+  category: overrides.category ?? GISCUS_CONFIG.category,
+  categoryId: overrides.categoryId ?? GISCUS_CONFIG.categoryId,
+  mapping: overrides.mapping ?? GISCUS_CONFIG.mapping,
+  strict: overrides.strict ?? GISCUS_CONFIG.strict,
+  reactionsEnabled: overrides.reactionsEnabled ?? GISCUS_CONFIG.reactionsEnabled,
+  emitMetadata: overrides.emitMetadata ?? GISCUS_CONFIG.emitMetadata,
+  inputPosition: overrides.inputPosition ?? GISCUS_CONFIG.inputPosition,
+  lang: overrides.lang ?? GISCUS_CONFIG.lang,
+};
+
+const configured = isGiscusConfigured(config);
+---
+
+<section class:list={['comments', className]} aria-labelledby="comments-heading">
+  <h2 id="comments-heading" class="comments__heading">コメント</h2>
+
+  {
+    configured ? (
+      <div
+        class="comments__giscus"
+        data-giscus-root
+        data-origin={GISCUS_ORIGIN}
+        data-script-src={GISCUS_SCRIPT_SRC}
+        data-repo={config.repo}
+        data-repo-id={config.repoId}
+        data-category={config.category}
+        data-category-id={config.categoryId}
+        data-mapping={config.mapping}
+        data-term={term}
+        data-strict={config.strict}
+        data-reactions-enabled={config.reactionsEnabled}
+        data-emit-metadata={config.emitMetadata}
+        data-input-position={config.inputPosition}
+        data-lang={config.lang}
+      >
+        <p class="comments__status" role="status">
+          コメントを読み込んでいます…
+        </p>
+      </div>
+    ) : (
+      <p class="comments__placeholder" role="note">
+        コメント機能は現在準備中です。
+      </p>
+    )
+  }
+</section>
+
+<style>
+  .comments {
+    margin-top: var(--space-16);
+    padding-top: var(--space-8);
+    border-top: 1px solid var(--border);
+  }
+
+  .comments__heading {
+    font-size: 1.25rem;
+    font-weight: 600;
+    text-transform: none;
+    letter-spacing: -0.01em;
+    margin: 0 0 var(--space-6);
+    color: var(--fg);
+  }
+
+  /* iframe が入るまでの最小高さ確保＝レイアウトシフト防止 */
+  .comments__giscus {
+    min-height: 8rem;
+  }
+
+  /* giscus が生成する iframe をレスポンシブに */
+  .comments__giscus :global(.giscus),
+  .comments__giscus :global(.giscus-frame) {
+    width: 100%;
+  }
+
+  .comments__status,
+  .comments__placeholder {
+    font-size: 0.875rem;
+    color: var(--fg-subtle);
+    margin: 0;
+  }
+</style>
+
+<script is:inline>
+  // is:inline でクライアント実行（既存 ThemeToggle と同じ流儀）。
+  (() => {
+    const root = document.querySelector('[data-giscus-root]');
+    if (!root || root.dataset.giscusLoaded) return;
+
+    const ORIGIN = root.dataset.origin;
+
+    // サイトの実効テーマ('light'/'dark')。data-theme が無い(=auto)場合は OS 設定にフォールバック。
+    function effectiveTheme() {
+      const t = document.documentElement.dataset.theme;
+      if (t === 'light' || t === 'dark') return t;
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+
+    // giscus へ渡すテーマ。公式テーマを土台にリアクションを控えめにした
+    // 自前 CSS（/giscus/{light,dark}.css）の絶対 URL を指定する。
+    // location.origin 基準なので dev は localhost、本番は本番ドメインを読む。
+    function giscusTheme() {
+      return location.origin + '/giscus/' + effectiveTheme() + '.css';
+    }
+
+    function postTheme() {
+      const frame = root.querySelector('iframe.giscus-frame');
+      if (!frame || !frame.contentWindow) return;
+      frame.contentWindow.postMessage(
+        { giscus: { setConfig: { theme: giscusTheme() } } },
+        ORIGIN,
+      );
+    }
+
+    function load() {
+      if (root.dataset.giscusLoaded) return;
+      root.dataset.giscusLoaded = 'true';
+
+      const s = document.createElement('script');
+      s.src = root.dataset.scriptSrc;
+      s.async = true;
+      s.crossOrigin = 'anonymous';
+      s.setAttribute('data-repo', root.dataset.repo);
+      s.setAttribute('data-repo-id', root.dataset.repoId);
+      s.setAttribute('data-category', root.dataset.category);
+      s.setAttribute('data-category-id', root.dataset.categoryId);
+      s.setAttribute('data-mapping', root.dataset.mapping);
+      s.setAttribute('data-term', root.dataset.term);
+      s.setAttribute('data-strict', root.dataset.strict);
+      s.setAttribute('data-reactions-enabled', root.dataset.reactionsEnabled);
+      s.setAttribute('data-emit-metadata', root.dataset.emitMetadata);
+      s.setAttribute('data-input-position', root.dataset.inputPosition);
+      s.setAttribute('data-theme', giscusTheme());
+      s.setAttribute('data-lang', root.dataset.lang);
+      // 公式の遅延ロード（iframe を loading="lazy" で挿入）。
+      s.setAttribute('data-loading', 'lazy');
+      root.appendChild(s);
+    }
+
+    // 1) コメント欄が近づいたら読み込む（本文の表示を優先）。
+    if ('IntersectionObserver' in window) {
+      const io = new IntersectionObserver(
+        (entries) => {
+          for (const entry of entries) {
+            if (entry.isIntersecting) {
+              io.disconnect();
+              load();
+            }
+          }
+        },
+        { rootMargin: '200px 0px' },
+      );
+      io.observe(root);
+    } else {
+      load();
+    }
+
+    // 2) giscus からの最初のメッセージで「読み込み中」表示を消す。
+    window.addEventListener('message', (event) => {
+      if (event.origin !== ORIGIN) return;
+      const data = event.data;
+      if (!data || typeof data !== 'object' || !('giscus' in data)) return;
+      const status = root.querySelector('.comments__status');
+      if (status) status.remove();
+      // 必要なら data.giscus.discussion からコメント数/リアクション数を取得可能
+      // （emit-metadata を有効化しているため）。
+    });
+
+    // 3) テーマ同期: トグル操作(themechange) と OS 設定変更(auto時) を反映。
+    document.addEventListener('themechange', postTheme);
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+      if (!document.documentElement.dataset.theme) postTheme();
+    });
+  })();
+</script>

--- a/src/config/giscus.ts
+++ b/src/config/giscus.ts
@@ -1,0 +1,56 @@
+// giscus（GitHub Discussions ベースのコメント機能）の一元設定。
+//
+// 値はあとから差し替える前提のプレースホルダー。コード側で参照するのはこの
+// ファイルだけにして、リポジトリ移行やカテゴリ変更が 1 箇所で済むようにする。
+// giscus.app で発行した実値を下の定数に貼り替えればよい。
+
+export type GiscusMapping = 'pathname' | 'url' | 'title' | 'og:title' | 'specific' | 'number';
+export type GiscusInputPosition = 'top' | 'bottom';
+/** giscus の data-* 属性は文字列の '0' / '1' を取る */
+export type GiscusFlag = '0' | '1';
+
+export interface GiscusConfig {
+  /** "owner/repo" */
+  repo: string;
+  repoId: string;
+  category: string;
+  categoryId: string;
+  mapping: GiscusMapping;
+  /** タイトル完全一致を強制するか。term が一意なら不要なので '0' */
+  strict: GiscusFlag;
+  reactionsEnabled: GiscusFlag;
+  emitMetadata: GiscusFlag;
+  inputPosition: GiscusInputPosition;
+  lang: string;
+}
+
+export const GISCUS_CONFIG: GiscusConfig = {
+  repo: 'cilly-yllic/cilly-yllic.github.io',
+  repoId: 'R_kgDOKAZ3rw',
+  category: 'Announcements',
+  categoryId: 'DIC_kwDOKAZ3r84DAMwW',
+  // mapping は specific を採用（理由は Giscus.astro 上部のコメント参照）。
+  mapping: 'specific',
+  strict: '0',
+  reactionsEnabled: '1',
+  emitMetadata: '1',
+  inputPosition: 'top',
+  lang: 'ja',
+};
+
+export const GISCUS_ORIGIN = 'https://giscus.app';
+export const GISCUS_SCRIPT_SRC = `${GISCUS_ORIGIN}/client.js`;
+
+/**
+ * 記事 (note.id = "<category>/<slug>") を Discussion の検索語(term)へ変換する。
+ * note.id は URL を変えても不変なので、これを term に使うと URL 変更に強い。
+ * mapping: 'specific' のとき giscus はこの term をそのまま Discussion タイトルにする。
+ */
+export function termForNote(noteId: string): string {
+  return noteId;
+}
+
+/** プレースホルダーのままなら未設定とみなす（カウント取得やウィジェット描画をスキップ）。 */
+export function isGiscusConfigured(config: GiscusConfig = GISCUS_CONFIG): boolean {
+  return !config.repo.includes('YOUR_') && !config.repoId.includes('YOUR_');
+}

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -4,6 +4,12 @@ interface ImportMetaEnv {
   readonly PUBLIC_GA_MEASUREMENT_ID?: string;
 }
 
+// ビルド時のみ参照する（クライアントへは出力しない）GitHub トークン用。
+// @types/node を入れずに process.env を型安全に使うための最小宣言。
+declare const process: {
+  readonly env: Record<string, string | undefined>;
+};
+
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }

--- a/src/lib/discussions.ts
+++ b/src/lib/discussions.ts
@@ -1,0 +1,124 @@
+// ビルド時に GitHub Discussions を取得し、記事一覧にコメント数・いいね(リアクション)数を
+// 表示するためのユーティリティ。
+//
+// 静的サイト (SSG) なのでカウントは「最後にビルドした時点」のスナップショット。
+// GitHub Actions では自動付与される GITHUB_TOKEN を使えるため、デプロイのたびに更新される。
+//
+// token 未設定 / repo 未設定 / 取得失敗のいずれでも空 Map を返し、ビルドは止めない
+// （その場合カードにカウントは出ない＝グレースフルデグレード）。
+
+import { GISCUS_CONFIG, isGiscusConfigured } from '../config/giscus';
+
+export interface DiscussionStat {
+  /** トップレベルのコメント数 */
+  comments: number;
+  /** Discussion 本体へのリアクション数（= いいね） */
+  reactions: number;
+  url: string;
+}
+
+interface DiscussionNode {
+  title: string;
+  url: string;
+  comments: { totalCount: number };
+  reactions: { totalCount: number };
+}
+
+interface GraphQLResponse {
+  data?: {
+    repository?: {
+      discussions: {
+        pageInfo: { hasNextPage: boolean; endCursor: string | null };
+        nodes: DiscussionNode[];
+      };
+    } | null;
+  };
+  errors?: { message: string }[];
+}
+
+const QUERY = `
+  query ($owner: String!, $name: String!, $category: ID, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+      discussions(first: 100, after: $cursor, categoryId: $category) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          title
+          url
+          comments { totalCount }
+          reactions { totalCount }
+        }
+      }
+    }
+  }
+`;
+
+async function fetchDiscussionStats(): Promise<Map<string, DiscussionStat>> {
+  const result = new Map<string, DiscussionStat>();
+
+  const token = process.env.GISCUS_GITHUB_TOKEN ?? process.env.GITHUB_TOKEN;
+  if (!token || !isGiscusConfigured()) return result;
+
+  const [owner, name] = GISCUS_CONFIG.repo.split('/');
+  if (!owner || !name) return result;
+
+  try {
+    let cursor: string | null = null;
+    // ページネーション（100 件/ページ）。1000 件で安全弁。
+    for (let page = 0; page < 10; page++) {
+      const res = await fetch('https://api.github.com/graphql', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: QUERY,
+          variables: {
+            owner,
+            name,
+            category: GISCUS_CONFIG.categoryId,
+            cursor,
+          },
+        }),
+      });
+
+      if (!res.ok) {
+        console.warn(`[discussions] GitHub API responded ${res.status}; skipping counts.`);
+        break;
+      }
+
+      const json = (await res.json()) as GraphQLResponse;
+      if (json.errors?.length) {
+        console.warn(`[discussions] GraphQL error: ${json.errors[0].message}; skipping counts.`);
+        break;
+      }
+
+      const discussions = json.data?.repository?.discussions;
+      if (!discussions) break;
+
+      for (const node of discussions.nodes) {
+        // mapping: 'specific' では Discussion タイトル === term (= note.id)。
+        result.set(node.title, {
+          comments: node.comments.totalCount,
+          reactions: node.reactions.totalCount,
+          url: node.url,
+        });
+      }
+
+      if (!discussions.pageInfo.hasNextPage) break;
+      cursor = discussions.pageInfo.endCursor;
+    }
+  } catch (err) {
+    console.warn('[discussions] Failed to fetch discussion stats; skipping counts.', err);
+  }
+
+  return result;
+}
+
+// 複数ページが import するため、ビルド中は 1 回だけ取得してキャッシュする。
+let cache: Promise<Map<string, DiscussionStat>> | null = null;
+
+export function getDiscussionStats(): Promise<Map<string, DiscussionStat>> {
+  if (!cache) cache = fetchDiscussionStats();
+  return cache;
+}

--- a/src/pages/notes/[category]/[slug].astro
+++ b/src/pages/notes/[category]/[slug].astro
@@ -2,7 +2,9 @@
 import type { GetStaticPaths } from 'astro';
 import { getCollection, render } from 'astro:content';
 import BaseLayout from '../../../layouts/BaseLayout.astro';
+import Giscus from '../../../components/Giscus.astro';
 import { CATEGORIES } from '../../../content.config';
+import { termForNote } from '../../../config/giscus';
 
 export const getStaticPaths = (async () => {
   const notes = await getCollection('notes', ({ data }) => !data.draft);
@@ -72,6 +74,8 @@ const ldJson = {
     <div class="prose">
       <Content />
     </div>
+
+    <Giscus term={termForNote(note.id)} />
   </article>
 </BaseLayout>
 

--- a/src/pages/notes/[category]/index.astro
+++ b/src/pages/notes/[category]/index.astro
@@ -4,6 +4,8 @@ import { getCollection } from 'astro:content';
 import BaseLayout from '../../../layouts/BaseLayout.astro';
 import ArticleCard from '../../../components/ArticleCard.astro';
 import { CATEGORIES, type CategorySlug } from '../../../content.config';
+import { termForNote } from '../../../config/giscus';
+import { getDiscussionStats } from '../../../lib/discussions';
 
 export const getStaticPaths = (async () => {
   return CATEGORIES.map((cat) => ({
@@ -26,6 +28,8 @@ const notes = await getCollection(
 const sorted = notes.sort(
   (a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime(),
 );
+
+const stats = await getDiscussionStats();
 
 // 本文 markdown から最初の画像（![alt](src)）を取り出す
 function firstImage(body?: string) {
@@ -50,6 +54,7 @@ function firstImage(body?: string) {
       ) : (
         sorted.map((note) => {
           const img = firstImage(note.body);
+          const stat = stats.get(termForNote(note.id));
           return (
             <ArticleCard
               title={note.data.title}
@@ -60,6 +65,8 @@ function firstImage(body?: string) {
               image={img?.src}
               imageAlt={img?.alt}
               showCategory={false}
+              commentCount={stat?.comments}
+              reactionCount={stat?.reactions}
             />
           );
         })

--- a/src/pages/notes/index.astro
+++ b/src/pages/notes/index.astro
@@ -4,12 +4,16 @@ import { Image } from 'astro:assets';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import ArticleCard from '../../components/ArticleCard.astro';
 import { CATEGORIES, type CategorySlug } from '../../content.config';
+import { termForNote } from '../../config/giscus';
+import { getDiscussionStats } from '../../lib/discussions';
 import heroImage from '../../assets/notes-hero.png';
 
 const allNotes = await getCollection('notes', ({ data }) => !data.draft);
 const sorted = allNotes.sort(
   (a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime(),
 );
+
+const stats = await getDiscussionStats();
 
 function entryHref(id: string) {
   return `/notes/${id}/`;
@@ -69,6 +73,7 @@ function firstImage(body?: string) {
       {
         sorted.map((note) => {
           const img = firstImage(note.body);
+          const stat = stats.get(termForNote(note.id));
           return (
             <ArticleCard
               title={note.data.title}
@@ -78,6 +83,8 @@ function firstImage(body?: string) {
               href={entryHref(note.id)}
               image={img?.src}
               imageAlt={img?.alt}
+              commentCount={stat?.comments}
+              reactionCount={stat?.reactions}
             />
           );
         })


### PR DESCRIPTION
## 概要
記事ページに giscus（GitHub Discussions）ベースのコメント機能を追加し、記事一覧にコメント数・いいね（リアクション）数を表示する。

## 変更内容
### コメント機能（記事ページのみ）
- `src/components/Giscus.astro` … 公式 `client.js` を使うコメント欄。設定は `src/config/giscus.ts` に集約し props で上書き可能
- Mapping は **`specific`**（term = `note.id`）を採用 → URL/タイトル変更に強い
- `IntersectionObserver` による遅延ロード（本文表示を優先）
- サイトの `data-theme`（Light/Dark）と giscus テーマをリロードなしで同期
- `public/giscus/{light,dark}.css` … 公式テーマを `@import` しつつリアクションバーを控えめに

### 記事一覧のコメント数・いいね数
- `src/lib/discussions.ts` … ビルド時に GitHub Discussions(GraphQL) から件数取得（メモ化・失敗時は非表示）
- `src/components/DiscussionStats.astro` … カウントバッジ
- `ArticleCard` / 一覧2ページに `commentCount` / `reactionCount` を連携

### デプロイ
- `static.yml` に `discussions: read` と `GISCUS_GITHUB_TOKEN: \${{ github.token }}` を追加（Secrets 登録不要）

## 確認
- `npm run check` / `build` / `lint` / `format:check` すべてパス
- giscus 実値（repo / repoId / categoryId）は設定済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)