### PR TITLE
Release: コメント改善（ツールチップ見切れ修正 + GitHub 直リンク）

### DIFF
--- a/public/giscus/dark.css
+++ b/public/giscus/dark.css
@@ -5,17 +5,17 @@
  */
 @import url("https://giscus.app/themes/dark.css");
 
-/* リアクションバーを小さく・右寄せ・余白圧縮（本文直後の主張を抑える） */
+/*
+ * リアクションバーを控えめに（小さく・余白圧縮・少し淡く）。
+ * ※ 右端へ寄せると、ホバー時のツールチップが iframe 端で見切れるため
+ *   right 寄せはせず giscus 既定の配置のままサイズだけ抑える。
+ */
 .gsc-reactions {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  font-size: 0.82em;
+  font-size: 0.85em;
   margin: 0 0 0.5rem;
 }
 
 .gsc-reactions-count {
-  margin-bottom: 0.25rem;
   opacity: 0.85;
 }
 

--- a/public/giscus/light.css
+++ b/public/giscus/light.css
@@ -5,17 +5,17 @@
  */
 @import url("https://giscus.app/themes/light.css");
 
-/* リアクションバーを小さく・右寄せ・余白圧縮（本文直後の主張を抑える） */
+/*
+ * リアクションバーを控えめに（小さく・余白圧縮・少し淡く）。
+ * ※ 右端へ寄せると、ホバー時のツールチップが iframe 端で見切れるため
+ *   right 寄せはせず giscus 既定の配置のままサイズだけ抑える。
+ */
 .gsc-reactions {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  font-size: 0.82em;
+  font-size: 0.85em;
   margin: 0 0 0.5rem;
 }
 
 .gsc-reactions-count {
-  margin-bottom: 0.25rem;
   opacity: 0.85;
 }
 

--- a/src/components/Giscus.astro
+++ b/src/components/Giscus.astro
@@ -44,6 +44,11 @@ const config: GiscusConfig = {
 };
 
 const configured = isGiscusConfigured(config);
+
+// サードパーティ Cookie ブロック等で giscus 上のサインインができない人向けの逃げ道。
+// GitHub(=ファーストパーティ)上で直接コメントできるよう、該当 term の
+// Discussions 検索 URL を初期値にする。実際の Discussion URL が判れば JS で差し替える。
+const discussionsFallbackUrl = `https://github.com/${config.repo}/discussions?discussions_q=${encodeURIComponent(term)}`;
 ---
 
 <section class:list={['comments', className]} aria-labelledby="comments-heading">
@@ -51,9 +56,10 @@ const configured = isGiscusConfigured(config);
 
   {
     configured ? (
-      <div
-        class="comments__giscus"
-        data-giscus-root
+      <Fragment>
+        <div
+          class="comments__giscus"
+          data-giscus-root
         data-origin={GISCUS_ORIGIN}
         data-script-src={GISCUS_SCRIPT_SRC}
         data-repo={config.repo}
@@ -72,6 +78,18 @@ const configured = isGiscusConfigured(config);
           コメントを読み込んでいます…
         </p>
       </div>
+      <p class="comments__fallback">
+        コメントできない場合は
+        <a
+          data-giscus-link
+          href={discussionsFallbackUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          GitHub で開く ↗
+        </a>
+      </p>
+      </Fragment>
     ) : (
       <p class="comments__placeholder" role="note">
         コメント機能は現在準備中です。
@@ -112,6 +130,21 @@ const configured = isGiscusConfigured(config);
     font-size: 0.875rem;
     color: var(--fg-subtle);
     margin: 0;
+  }
+
+  .comments__fallback {
+    margin: var(--space-3) 0 0;
+    font-size: 0.8125rem;
+    color: var(--fg-subtle);
+  }
+
+  .comments__fallback a {
+    color: var(--fg-muted);
+    text-underline-offset: 3px;
+  }
+
+  .comments__fallback a:hover {
+    color: var(--fg);
   }
 </style>
 
@@ -196,8 +229,13 @@ const configured = isGiscusConfigured(config);
       if (!data || typeof data !== 'object' || !('giscus' in data)) return;
       const status = root.querySelector('.comments__status');
       if (status) status.remove();
-      // 必要なら data.giscus.discussion からコメント数/リアクション数を取得可能
-      // （emit-metadata を有効化しているため）。
+      // emit-metadata で送られてくる Discussion の実 URL があれば、
+      // フォールバックリンクを検索 URL から該当スレッドへ差し替える。
+      const url = data.giscus.discussion && data.giscus.discussion.url;
+      if (url) {
+        const link = document.querySelector('[data-giscus-link]');
+        if (link) link.setAttribute('href', url);
+      }
     });
 
     // 3) テーマ同期: トグル操作(themechange) と OS 設定変更(auto時) を反映。


### PR DESCRIPTION
develop の内容を main へ反映しデプロイする。

## 含まれる変更
- #31 リアクションのツールチップ見切れ修正 + 「GitHub で開く」フォールバックリンク追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)