### PR TITLE
公開: dev.to 第1弾 2本 (guardrails / firebase-contract)

### DIFF
--- a/devto/articles/contract-driven-firebase-codegen.md
+++ b/devto/articles/contract-driven-firebase-codegen.md
@@ -1,6 +1,6 @@
 ---
 title: "Generating every Firebase layer’s types from a single contract.yml"
-published: false
+published: true
 description: "One YAML contract as the source of truth — generating TypeScript, Zod, GraphQL, Firestore projections and API DTOs, drift caught in CI."
 tags: typescript, firebase, graphql, codegen
 canonical_url: https://cilly-yllic.github.io/en/notes/firebase-gcp/contract-driven-firebase-codegen/

--- a/devto/articles/scope-and-permission-guardrails-for-coding-agents.md
+++ b/devto/articles/scope-and-permission-guardrails-for-coding-agents.md
@@ -1,6 +1,6 @@
 ---
 title: "Enforce with config, not attention — scope and permission guardrails for coding agents"
-published: false
+published: true
 description: "Enforcing multi-repo coding-agent work with declared scopes and permissions — config that makes accidents impossible, not careful prompts."
 tags: ai, security, devops, productivity
 canonical_url: https://cilly-yllic.github.io/en/notes/ai-agents/scope-and-permission-guardrails-for-coding-agents/


### PR DESCRIPTION
dev.to 第1弾として 2 本を published: true に変更する。

- Enforce with config, not attention (AI エージェント領域でリーチ最大)
- Generating every Firebase layer's types from a single contract.yml (firebase-contract の OSS 導線)

残り 4 本は draft のまま。変更のない記事は同期でスキップされる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)