### PR TITLE
Release: dev.to 第2弾 2本の公開

### DIFF
--- a/devto/articles/config-driven-gcp-firebase-provisioning.md
+++ b/devto/articles/config-driven-gcp-firebase-provisioning.md
@@ -1,6 +1,6 @@
 ---
 title: "Provisioning GCP / Firebase environments from a single settings.yml"
-published: false
+published: true
 description: "Config-driven, keyless provisioning: one settings.yml per service generates everything from the GCP project to Firebase resources."
 tags: terraform, gcp, firebase, cicd
 canonical_url: https://cilly-yllic.github.io/en/notes/firebase-gcp/config-driven-gcp-firebase-provisioning/

--- a/devto/articles/firestore-as-public-cache.md
+++ b/devto/articles/firestore-as-public-cache.md
@@ -1,6 +1,6 @@
 ---
 title: "Treating Firestore as a public cache"
-published: false
+published: true
 description: "Cloud SQL as the source of truth, Firestore as a rebuildable read projection — the design benefits and the costs."
 tags: firebase, database, architecture, gcp
 canonical_url: https://cilly-yllic.github.io/en/notes/firebase-gcp/firestore-as-public-cache/


### PR DESCRIPTION
dev.to 第2弾 (provisioning / firestore-cache) を公開する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)